### PR TITLE
Add Karabiner-Elements config

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Create local files as needed, then customize locally. The `*.local.*` files are 
 # Install vundle: https://github.com/VundleVim/Vundle.vim
 # Add unix-config/scripts directory to your shell PATH (for example in .zshrc)
 
+brew install --cask karabiner-elements
 brew install git
 brew install git-delta
 brew install yarn

--- a/karabiner/karabiner.json
+++ b/karabiner/karabiner.json
@@ -1,0 +1,142 @@
+{
+    "global": { "show_in_menu_bar": false },
+    "profiles": [
+        {
+            "complex_modifications": {
+                "rules": [
+                    {
+                        "description": "XCode: kj",
+                        "enabled": false,
+                        "manipulators": [
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "com.apple.dt.Xcode"
+                                        ],
+                                        "type": "frontmost_application_if"
+                                    },
+                                    {
+                                        "name": "k_pressed",
+                                        "type": "variable_unless",
+                                        "value": 1
+                                    }
+                                ],
+                                "from": { "key_code": "k" },
+                                "parameters": { "basic.to_delayed_action_delay_milliseconds": 500 },
+                                "to": [
+                                    {
+                                        "set_variable": {
+                                            "name": "k_pressed",
+                                            "value": 1
+                                        }
+                                    }
+                                ],
+                                "to_delayed_action": {
+                                    "to_if_invoked": [
+                                        {
+                                            "set_variable": {
+                                                "name": "k_pressed",
+                                                "value": 0
+                                            }
+                                        }
+                                    ]
+                                },
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "com.apple.dt.Xcode"
+                                        ],
+                                        "type": "frontmost_application_if"
+                                    },
+                                    {
+                                        "name": "k_pressed",
+                                        "type": "variable_if",
+                                        "value": 1
+                                    }
+                                ],
+                                "from": { "key_code": "j" },
+                                "to": [
+                                    {
+                                        "set_variable": {
+                                            "name": "k_pressed",
+                                            "value": 0
+                                        }
+                                    },
+                                    {
+                                        "key_code": "escape",
+                                        "modifiers": []
+                                    }
+                                ],
+                                "type": "basic"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "devices": [
+                {
+                    "identifiers": {
+                        "is_keyboard": true,
+                        "product_id": 28705,
+                        "vendor_id": 1256
+                    },
+                    "simple_modifications": [
+                        {
+                            "from": { "apple_vendor_top_case_key_code": "keyboard_fn" },
+                            "to": [{ "key_code": "left_control" }]
+                        },
+                        {
+                            "from": { "key_code": "caps_lock" },
+                            "to": [{ "key_code": "grave_accent_and_tilde" }]
+                        },
+                        {
+                            "from": { "key_code": "grave_accent_and_tilde" },
+                            "to": [{ "key_code": "escape" }]
+                        }
+                    ]
+                },
+                {
+                    "identifiers": {
+                        "is_keyboard": true,
+                        "product_id": 264,
+                        "vendor_id": 12046
+                    },
+                    "simple_modifications": [
+                        {
+                            "from": { "key_code": "left_command" },
+                            "to": [{ "key_code": "left_option" }]
+                        },
+                        {
+                            "from": { "key_code": "left_option" },
+                            "to": [{ "key_code": "left_command" }]
+                        }
+                    ]
+                },
+                {
+                    "identifiers": {
+                        "is_keyboard": true,
+                        "product_id": 8455,
+                        "vendor_id": 16700
+                    },
+                    "simple_modifications": [
+                        {
+                            "from": { "key_code": "left_command" },
+                            "to": [{ "key_code": "left_option" }]
+                        },
+                        {
+                            "from": { "key_code": "left_option" },
+                            "to": [{ "key_code": "left_command" }]
+                        }
+                    ]
+                }
+            ],
+            "name": "Default profile",
+            "selected": true,
+            "virtual_hid_keyboard": { "keyboard_type_v2": "ansi" }
+        }
+    ]
+}

--- a/make_links
+++ b/make_links
@@ -12,6 +12,7 @@ echo "    .tmux.conf"
 echo "    .vimrc"
 echo "    .zshrc"
 echo "    .zshrc.d"
+echo "    .config/karabiner"
 echo
 read -p "Proceed? (y/N): " -n 1 -r
 echo
@@ -32,6 +33,9 @@ then
     ln -s $SCRIPT_DIR/.vimrc        ~/.vimrc
     ln -s $SCRIPT_DIR/.zshrc        ~/.zshrc
     ln -s $SCRIPT_DIR/.zshrc.d      ~/.zshrc.d
+    mkdir -p ~/.config
+    [ -e ~/.config/karabiner ] && trash ~/.config/karabiner
+    ln -s $SCRIPT_DIR/karabiner     ~/.config/karabiner
     echo
     echo Done.
     ls -o ~/.gitconfig
@@ -41,6 +45,7 @@ then
     ls -o ~/.vimrc
     ls -o ~/.zshrc
     ls -o ~/.zshrc.d
+    ls -o ~/.config/karabiner
     echo
 else
     echo Denied!


### PR DESCRIPTION
## Summary
- Adds `karabiner/karabiner.json` with key remaps for 3 keyboards (Command/Option swap on external boards, Fn/CapsLock/backtick remaps on built-in)
- Updates `make_links` to symlink `~/.config/karabiner` to the repo copy
- Adds `brew install --cask karabiner-elements` to README install instructions

## Test plan
- [ ] Run `./make_links` on a fresh machine and verify `~/.config/karabiner` points to the repo
- [ ] Open Karabiner-Elements and confirm the remaps load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)