### PR TITLE
Split exports from .zshrc into .zshenv

### DIFF
--- a/.zshenv
+++ b/.zshenv
@@ -1,0 +1,38 @@
+# Environment variables and PATH — loaded for ALL shell types
+# (interactive, non-interactive, login, scripts, Claude Code, etc.)
+
+# Exports
+export ANDROID_HOME=~/Library/Android/sdk
+export PATH=$PATH:$ANDROID_HOME
+export PATH=$PATH:$ANDROID_HOME/tools
+export PATH=$PATH:$ANDROID_HOME/platform-tools
+
+export PATH=$PATH:~/Documents/unix-config/scripts
+export PATH=$PATH:/opt/homebrew/bin
+
+export PATH=$PATH:$HOME/.mint/bin
+
+export PATH=~/.asdf/shims:$PATH
+
+[[ -s "$HOME/.rvm/scripts/rvm" ]] && source "$HOME/.rvm/scripts/rvm" # Load RVM into a shell session *as a function*
+
+export NVM_DIR="$HOME/.nvm"
+[ -s "/opt/homebrew/opt/nvm/nvm.sh" ] && \. "/opt/homebrew/opt/nvm/nvm.sh"  # This loads nvm
+[ -s "/opt/homebrew/opt/nvm/etc/bash_completion.d/nvm" ] && \. "/opt/homebrew/opt/nvm/etc/bash_completion.d/nvm"
+
+# Ruby
+# eval "$(rbenv init - zsh)"
+export PATH="/opt/homebrew/opt/ruby/bin:$PATH"
+
+export PATH="$HOME/.local/bin:$PATH"
+
+# Codex
+export CODEX_HOME="$HOME/.agents"
+
+# Local overrides and secrets (untracked)
+[ -f "$HOME/.zshrc.local" ] && source "$HOME/.zshrc.local"
+if [ -d "$HOME/.zshrc.d" ]; then
+  for file in "$HOME/.zshrc.d/"*.local.zsh(.N); do
+    [ -f "$file" ] && source "$file"
+  done
+fi

--- a/.zshrc
+++ b/.zshrc
@@ -1,3 +1,6 @@
+# Interactive shell configuration — aliases, functions, prompt, completions
+# Environment variables and PATH are in .zshenv (loaded for all shell types)
+
 # Functions
 
 cdl() {
@@ -59,6 +62,8 @@ alias gds="git diff --staged"
 alias jwt=jwt
 alias pjq="pbpaste | jq"
 alias sp="spatialite"
+alias cls='claude --dangerously-skip-permissions'
+alias cdls='codex --dangerously-bypass-approvals-and-sandbox'
 
 # History
 HISTFILE=~/.zsh_history
@@ -81,47 +86,8 @@ autoload -Uz compinit && compinit
 setopt prompt_subst
 PROMPT='%F{51}%~%F{5}$(parse_git_branch)%F{7}$(parse_git_status)%F{2}$%f '
 
-# Exports
-
-export ANDROID_HOME=~/Library/Android/sdk
-export PATH=$PATH:$ANDROID_HOME
-export PATH=$PATH:$ANDROID_HOME/tools
-export PATH=$PATH:$ANDROID_HOME/platform-tools
-
-export PATH=$PATH:~/Documents/unix-config/scripts
-export PATH=$PATH:/opt/homebrew/bin
-
-export PATH=$PATH:$HOME/.mint/bin
-
-export PATH=~/.asdf/shims:$PATH
-
-[[ -s "$HOME/.rvm/scripts/rvm" ]] && source "$HOME/.rvm/scripts/rvm" # Load RVM into a shell session *as a function*
-
-export NVM_DIR="$HOME/.nvm"
-[ -s "/opt/homebrew/opt/nvm/nvm.sh" ] && \. "/opt/homebrew/opt/nvm/nvm.sh"  # This loads nvm
-[ -s "/opt/homebrew/opt/nvm/etc/bash_completion.d/nvm" ] && \. "/opt/homebrew/opt/nvm/etc/bash_completion.d/nvm"  # This lo
-
-
-# Ruby
-# eval "$(rbenv init - zsh)"
-export PATH="/opt/homebrew/opt/ruby/bin:$PATH"
-
-alias cls='claude --dangerously-skip-permissions'
-alias cdls='codex --dangerously-bypass-approvals-and-sandbox'
-
-# Added as suggested by Claude Code
-export PATH="$HOME/.local/bin:$PATH"
-
-# Codex
-export CODEX_HOME="$HOME/.agents"
-
-# Local overrides and secrets (untracked)
-[ -f "$HOME/.zshrc.local" ] && source "$HOME/.zshrc.local"
-if [ -d "$HOME/.zshrc.d" ]; then
-  for file in "$HOME/.zshrc.d/"*.local.zsh(.N); do
-    [ -f "$file" ] && source "$file"
-  done
-fi
+# nvm bash completion (interactive only)
+[ -s "/opt/homebrew/opt/nvm/etc/bash_completion.d/nvm" ] && \. "/opt/homebrew/opt/nvm/etc/bash_completion.d/nvm"
 
 # dcg: warn if hook was silently removed from Claude Code settings
 if command -v dcg &>/dev/null && command -v jq &>/dev/null; then

--- a/make_links
+++ b/make_links
@@ -10,6 +10,7 @@ echo "    .inputrc"
 echo "    .jumpdests"
 echo "    .tmux.conf"
 echo "    .vimrc"
+echo "    .zshenv"
 echo "    .zshrc"
 echo "    .zshrc.d"
 echo "    .config/karabiner"
@@ -24,6 +25,7 @@ then
     [ -e ~/.jumpdests ] && trash ~/.jumpdests
     [ -e ~/.tmux.conf ] && trash ~/.tmux.conf
     [ -e ~/.vimrc ] && trash ~/.vimrc
+    [ -e ~/.zshenv ] && trash ~/.zshenv
     [ -e ~/.zshrc ] && trash ~/.zshrc
     [ -e ~/.zshrc.d ] && trash ~/.zshrc.d
     ln -s $SCRIPT_DIR/.gitconfig    ~/.gitconfig
@@ -31,6 +33,7 @@ then
     ln -s $SCRIPT_DIR/.jumpdests    ~/.jumpdests
     ln -s $SCRIPT_DIR/.tmux.conf    ~/.tmux.conf
     ln -s $SCRIPT_DIR/.vimrc        ~/.vimrc
+    ln -s $SCRIPT_DIR/.zshenv       ~/.zshenv
     ln -s $SCRIPT_DIR/.zshrc        ~/.zshrc
     ln -s $SCRIPT_DIR/.zshrc.d      ~/.zshrc.d
     mkdir -p ~/.config
@@ -45,6 +48,7 @@ then
     ls -o ~/.jumpdests
     ls -o ~/.tmux.conf
     ls -o ~/.vimrc
+    ls -o ~/.zshenv
     ls -o ~/.zshrc
     ls -o ~/.zshrc.d
     ls -o ~/.config/karabiner


### PR DESCRIPTION
## Summary
- Create `.zshenv` with all `export` statements, PATH additions, runtime initializers (nvm, rvm, asdf), and `.zshrc.d` secret sourcing
- Trim `.zshrc` to interactive-only config: aliases, functions, prompt, completions, history
- Update `make_links` to symlink `.zshenv`

## Why
`.zshrc` only runs for **interactive** shells. Tools like Claude Code run non-interactive login shells (`zshenv` → `zprofile` → skip `.zshrc`), so env vars like `LINEAR_API_TOKEN` were missing.

## Test plan
- [ ] Open a new terminal — verify aliases, prompt, completions still work
- [ ] Run `echo $LINEAR_API_TOKEN` in a new terminal — verify it's set
- [ ] Run `zsh -c 'echo $LINEAR_API_TOKEN'` (non-interactive) — verify it's set
- [ ] Start a new Claude Code session — verify `linearis` commands work without manual sourcing

🤖 Generated with [Claude Code](https://claude.com/claude-code)