### PR TITLE
Tint cmux sidebar to match terminal background

### DIFF
--- a/.config/cmux/config.ghostty
+++ b/.config/cmux/config.ghostty
@@ -7,8 +7,8 @@ window-width = 125
 window-height = 38
 
 background = #000000
-background-opacity = 0.85
-background-blur = 60
+background-opacity = 1.0
+background-blur = false
 
 foreground = #FFE0A4
 cursor-color = #BB5600

--- a/.config/cmux/settings.json
+++ b/.config/cmux/settings.json
@@ -181,6 +181,11 @@
   //   },
 
   "sidebarAppearance": {
-    "matchTerminalBackground": true
+    "matchTerminalBackground": true,
+    "tintOpacity": 1.0
+  },
+
+  "workspaceColors": {
+    "selectionColor": "#A67C2E"
   }
 }

--- a/.config/cmux/settings.json
+++ b/.config/cmux/settings.json
@@ -1,0 +1,186 @@
+{
+  "$schema": "https://raw.githubusercontent.com/manaflow-ai/cmux/main/web/data/cmux-settings.schema.json",
+  "schemaVersion": 1,
+
+  // This file uses JSON with comments (JSONC).
+  // Uncomment and edit any setting to make it file-managed.
+  // Remove a setting to fall back to the value saved in Settings.
+  // cmux creates this template on launch when both settings file locations are missing.
+  // ~/.config/cmux/settings.json takes precedence over the Application Support fallback.
+
+  //   "app" : {
+  //     "appearance" : "system",
+  //     "appIcon" : "automatic",
+  //     "commandPaletteSearchesAllSurfaces" : false,
+  //     "focusPaneOnFirstClick" : false,
+  //     "keepWorkspaceOpenWhenClosingLastSurface" : false,
+  //     "language" : "system",
+  //     "minimalMode" : false,
+  //     "newWorkspacePlacement" : "afterCurrent",
+  //     "preferredEditor" : "",
+  //     "renameSelectsExistingName" : true,
+  //     "reorderOnNotification" : true,
+  //     "sendAnonymousTelemetry" : true,
+  //     "warnBeforeQuit" : true
+  //   },
+
+  //   "notifications" : {
+  //     "command" : "",
+  //     "customSoundFilePath" : "",
+  //     "dockBadge" : true,
+  //     "paneFlash" : true,
+  //     "showInMenuBar" : true,
+  //     "sound" : "default",
+  //     "unreadPaneRing" : true
+  //   },
+
+  //   "sidebar" : {
+  //     "branchLayout" : "vertical",
+  //     "hideAllDetails" : false,
+  //     "openPortLinksInCmuxBrowser" : true,
+  //     "openPullRequestLinksInCmuxBrowser" : true,
+  //     "showBranchDirectory" : true,
+  //     "showCustomMetadata" : true,
+  //     "showLog" : true,
+  //     "showNotificationMessage" : true,
+  //     "showPorts" : true,
+  //     "showProgress" : true,
+  //     "showPullRequests" : true,
+  //     "showSSH" : true
+  //   },
+
+  //   "workspaceColors" : {
+  //     "colors" : {
+  //       "Amber" : "#7D6608",
+  //       "Aqua" : "#0E6B8C",
+  //       "Blue" : "#1565C0",
+  //       "Brown" : "#7B3F00",
+  //       "Charcoal" : "#3E4B5E",
+  //       "Crimson" : "#922B21",
+  //       "Green" : "#196F3D",
+  //       "Indigo" : "#283593",
+  //       "Magenta" : "#AD1457",
+  //       "Navy" : "#1A5276",
+  //       "Olive" : "#4A5C18",
+  //       "Orange" : "#A04000",
+  //       "Purple" : "#6A1B9A",
+  //       "Red" : "#C0392B",
+  //       "Rose" : "#880E4F",
+  //       "Teal" : "#006B6B"
+  //     },
+  //     "indicatorStyle" : "leftRail",
+  //     "notificationBadgeColor" : null,
+  //     "selectionColor" : null
+  //   },
+
+  //   "sidebarAppearance" : {
+  //     "darkModeTintColor" : null,
+  //     "lightModeTintColor" : null,
+  //     "matchTerminalBackground" : false,
+  //     "tintColor" : "#000000",
+  //     "tintOpacity" : 0.17999999999999999
+  //   },
+
+  //   "automation" : {
+  //     "claudeBinaryPath" : "",
+  //     "claudeCodeIntegration" : true,
+  //     "portBase" : 9100,
+  //     "portRange" : 10,
+  //     "socketControlMode" : "cmuxOnly",
+  //     "socketPassword" : ""
+  //   },
+
+  //   "customCommands" : {
+  //     "trustedDirectories" : [
+  // 
+  //     ]
+  //   },
+
+  //   "browser" : {
+  //     "defaultSearchEngine" : "google",
+  //     "hostsToOpenInEmbeddedBrowser" : [
+  // 
+  //     ],
+  //     "insecureHttpHostsAllowedInEmbeddedBrowser" : [
+  //       "localhost",
+  //       "127.0.0.1",
+  //       "::1",
+  //       "0.0.0.0",
+  //       "*.localtest.me"
+  //     ],
+  //     "interceptTerminalOpenCommandInCmuxBrowser" : true,
+  //     "openTerminalLinksInCmuxBrowser" : true,
+  //     "reactGrabVersion" : "0.1.29",
+  //     "showImportHintOnBlankTabs" : true,
+  //     "showSearchSuggestions" : true,
+  //     "theme" : "system",
+  //     "urlsToAlwaysOpenExternally" : [
+  // 
+  //     ]
+  //   },
+
+  //   "shortcuts" : {
+  //     "bindings" : {
+  //       "browserBack" : "cmd+[",
+  //       "browserForward" : "cmd+]",
+  //       "browserReload" : "cmd+r",
+  //       "browserZoomIn" : "cmd+=",
+  //       "browserZoomOut" : "cmd+-",
+  //       "browserZoomReset" : "cmd+0",
+  //       "closeOtherTabsInPane" : "cmd+opt+t",
+  //       "closeTab" : "cmd+w",
+  //       "closeWindow" : "cmd+ctrl+w",
+  //       "closeWorkspace" : "cmd+shift+w",
+  //       "commandPalette" : "cmd+shift+p",
+  //       "editWorkspaceDescription" : "cmd+shift+e",
+  //       "find" : "cmd+f",
+  //       "findNext" : "cmd+g",
+  //       "findPrevious" : "cmd+opt+g",
+  //       "focusBrowserAddressBar" : "cmd+l",
+  //       "focusDown" : "cmd+opt+↓",
+  //       "focusLeft" : "cmd+opt+←",
+  //       "focusRight" : "cmd+opt+→",
+  //       "focusUp" : "cmd+opt+↑",
+  //       "goToWorkspace" : "cmd+p",
+  //       "hideFind" : "cmd+shift+f",
+  //       "jumpToUnread" : "cmd+shift+u",
+  //       "newSurface" : "cmd+t",
+  //       "newTab" : "cmd+n",
+  //       "newWindow" : "cmd+shift+n",
+  //       "nextSidebarTab" : "cmd+ctrl+]",
+  //       "nextSurface" : "cmd+shift+]",
+  //       "openBrowser" : "cmd+shift+l",
+  //       "openFolder" : "cmd+o",
+  //       "openSettings" : "cmd+,",
+  //       "prevSidebarTab" : "cmd+ctrl+[",
+  //       "prevSurface" : "cmd+shift+[",
+  //       "quit" : "cmd+q",
+  //       "reloadConfiguration" : "cmd+shift+,",
+  //       "renameTab" : "cmd+r",
+  //       "renameWorkspace" : "cmd+shift+r",
+  //       "reopenClosedBrowserPanel" : "cmd+shift+t",
+  //       "selectSurfaceByNumber" : "ctrl+1",
+  //       "selectWorkspaceByNumber" : "cmd+1",
+  //       "sendFeedback" : "cmd+opt+f",
+  //       "showBrowserJavaScriptConsole" : "cmd+opt+c",
+  //       "showNotifications" : "cmd+i",
+  //       "splitBrowserDown" : "cmd+shift+opt+d",
+  //       "splitBrowserRight" : "cmd+opt+d",
+  //       "splitDown" : "cmd+shift+d",
+  //       "splitRight" : "cmd+d",
+  //       "toggleBrowserDeveloperTools" : "cmd+opt+i",
+  //       "toggleFullScreen" : "cmd+ctrl+f",
+  //       "toggleReactGrab" : "cmd+shift+g",
+  //       "toggleSidebar" : "cmd+b",
+  //       "toggleSplitZoom" : "cmd+shift+\r",
+  //       "toggleTerminalCopyMode" : "cmd+shift+m",
+  //       "triggerFlash" : "cmd+shift+h",
+  //       "useSelectionForFind" : "cmd+e"
+  //     },
+  //     "showModifierHoldHints" : true
+  //   },
+
+  "sidebarAppearance": {
+    "matchTerminalBackground": true
+  }
+}

--- a/make_links
+++ b/make_links
@@ -16,6 +16,7 @@ echo "    .zshrc.d"
 echo "    .config/cmux"
 echo "    .config/ghostty"
 echo "    .config/karabiner"
+echo "    ~/Library/Application Support/com.cmuxterm.app/config.ghostty"
 echo
 read -p "Proceed? (y/N): " -n 1 -r
 echo
@@ -47,6 +48,14 @@ then
     # Karabiner's core service runs as root and cannot follow symlinks,
     # so we copy instead of symlinking.
     cp -R $SCRIPT_DIR/karabiner     ~/.config/karabiner
+    # cmux is Ghostty-based but reads its Ghostty config from Application
+    # Support. Point it at a cmux-specific config (not Ghostty's) so the
+    # two can diverge where cmux's SwiftUI renderer misbehaves — notably,
+    # cmux's alpha stacking makes background-opacity unusable, so the
+    # cmux config stays fully opaque while Ghostty keeps its translucency.
+    mkdir -p ~/"Library/Application Support/com.cmuxterm.app"
+    [ -e ~/"Library/Application Support/com.cmuxterm.app/config.ghostty" ] && trash ~/"Library/Application Support/com.cmuxterm.app/config.ghostty"
+    ln -s "$SCRIPT_DIR/.config/cmux/config.ghostty" ~/"Library/Application Support/com.cmuxterm.app/config.ghostty"
     echo
     echo Done.
     ls -o ~/.gitconfig
@@ -60,6 +69,7 @@ then
     ls -o ~/.config/cmux
     ls -o ~/.config/ghostty
     ls -o ~/.config/karabiner
+    ls -o ~/"Library/Application Support/com.cmuxterm.app/config.ghostty"
     echo
 else
     echo Denied!

--- a/make_links
+++ b/make_links
@@ -13,6 +13,7 @@ echo "    .vimrc"
 echo "    .zshenv"
 echo "    .zshrc"
 echo "    .zshrc.d"
+echo "    .config/cmux"
 echo "    .config/ghostty"
 echo "    .config/karabiner"
 echo
@@ -38,6 +39,8 @@ then
     ln -s $SCRIPT_DIR/.zshrc        ~/.zshrc
     ln -s $SCRIPT_DIR/.zshrc.d      ~/.zshrc.d
     mkdir -p ~/.config
+    [ -e ~/.config/cmux ] && trash ~/.config/cmux
+    ln -s $SCRIPT_DIR/.config/cmux ~/.config/cmux
     [ -e ~/.config/ghostty ] && trash ~/.config/ghostty
     ln -s $SCRIPT_DIR/.config/ghostty ~/.config/ghostty
     [ -e ~/.config/karabiner ] && trash ~/.config/karabiner
@@ -54,6 +57,7 @@ then
     ls -o ~/.zshenv
     ls -o ~/.zshrc
     ls -o ~/.zshrc.d
+    ls -o ~/.config/cmux
     ls -o ~/.config/ghostty
     ls -o ~/.config/karabiner
     echo


### PR DESCRIPTION
## Summary
- Move `~/.config/cmux/settings.json` into this repo and enable `sidebarAppearance.matchTerminalBackground` so the cmux left-nav tints to the terminal's background color instead of the default slate.
- Kept the rest of the settings template as JSONC comments so future overrides have a clear reference.

## Test plan
- [x] cmux sidebar matches the Ghostty-themed terminal background after restart
- [ ] On a fresh machine, `./make_links` creates `~/.config/cmux` symlink

## Note
Stacks cleanly on top of #11 (cmux Ghostty-config symlink). The two touch adjacent lines in `make_links` — expect a trivial merge when both land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)