### PR TITLE
Split cmux and Ghostty configs; tune translucency per app

### DIFF
--- a/.config/cmux/config.ghostty
+++ b/.config/cmux/config.ghostty
@@ -7,8 +7,8 @@ window-width = 125
 window-height = 38
 
 background = #000000
-background-opacity = 0.85
-background-blur = 60
+background-opacity = 1.0
+background-blur = false
 
 foreground = #FFE0A4
 cursor-color = #BB5600

--- a/.config/cmux/settings.json
+++ b/.config/cmux/settings.json
@@ -181,6 +181,11 @@
   //   },
 
   "sidebarAppearance": {
-    "matchTerminalBackground": true
+    "matchTerminalBackground": true,
+    "tintOpacity": 1.0
+  },
+
+  "workspaceColors": {
+    "selectionColor": "#A67C2E"
   }
 }

--- a/make_links
+++ b/make_links
@@ -16,6 +16,7 @@ echo "    .zshrc.d"
 echo "    .config/cmux"
 echo "    .config/ghostty"
 echo "    .config/karabiner"
+echo "    ~/Library/Application Support/com.cmuxterm.app/config.ghostty"
 echo
 read -p "Proceed? (y/N): " -n 1 -r
 echo
@@ -47,6 +48,14 @@ then
     # Karabiner's core service runs as root and cannot follow symlinks,
     # so we copy instead of symlinking.
     cp -R $SCRIPT_DIR/karabiner     ~/.config/karabiner
+    # cmux is Ghostty-based but reads its Ghostty config from Application
+    # Support. Point it at a cmux-specific config (not Ghostty's) so the
+    # two can diverge where cmux's SwiftUI renderer misbehaves — notably,
+    # cmux's alpha stacking makes background-opacity unusable, so the
+    # cmux config stays fully opaque while Ghostty keeps its translucency.
+    mkdir -p ~/"Library/Application Support/com.cmuxterm.app"
+    [ -e ~/"Library/Application Support/com.cmuxterm.app/config.ghostty" ] && trash ~/"Library/Application Support/com.cmuxterm.app/config.ghostty"
+    ln -s "$SCRIPT_DIR/.config/cmux/config.ghostty" ~/"Library/Application Support/com.cmuxterm.app/config.ghostty"
     echo
     echo Done.
     ls -o ~/.gitconfig
@@ -60,6 +69,7 @@ then
     ls -o ~/.config/cmux
     ls -o ~/.config/ghostty
     ls -o ~/.config/karabiner
+    ls -o ~/"Library/Application Support/com.cmuxterm.app/config.ghostty"
     echo
 else
     echo Denied!


### PR DESCRIPTION
## Summary
cmux was sharing Ghostty's `config.ghostty` via symlink. But cmux's SwiftUI view tree stacks alpha ([manaflow-ai/cmux#2846](https://github.com/manaflow-ai/cmux/issues/2846)) which makes `background-opacity` behave binary — too translucent to read text, or fully opaque, with no usable middle. Split the configs so each app carries its own translucency settings.

## Changes
- **Ghostty** (`0.81/true` → `0.85/60`): nicer frosted look now that we're comfortable with a higher blur radius
- **cmux**: forced opaque (`opacity = 1.0`, `blur = false`) to dodge the stacking bug
- **cmux sidebar**: `tintOpacity = 1.0` so it stays opaque matching the (opaque) terminal; `workspaceColors.selectionColor = #A67C2E` replaces the harsh default `#1565C0` blue with a warm gold that fits the peach/orange palette
- **make_links**: creates a new symlink `~/Library/Application Support/com.cmuxterm.app/config.ghostty` → `.config/cmux/config.ghostty` (cmux-specific, not Ghostty's)

## Relationship to open PRs
- **Supersedes #11** — #11 pointed cmux at Ghostty's config, which this PR abandons in favor of the split. Close #11 in favor of this.
- **Stacks on #12** — depends on the `.config/cmux/` directory and sidebar settings.json introduced there.

## Test plan
- [x] Ghostty translucent with frosted blur
- [x] cmux terminal fully opaque, text legible
- [x] cmux sidebar opaque, color-matches terminal
- [x] Selected workspace reads cleanly with white text on gold
- [ ] On a fresh machine, `./make_links` wires up both symlinks

🤖 Generated with [Claude Code](https://claude.com/claude-code)